### PR TITLE
Add nofollow and Dont show similar for googlebot

### DIFF
--- a/templates/_items.html
+++ b/templates/_items.html
@@ -46,7 +46,7 @@
           </div>
         {% endif %}
         <div style="padding-top: 5px">
-          <a href="{{ product.get_similar }}?{% remove_page_parameter request=request %}" class="link--clean">
+          <a href="{{ product.get_similar }}?{% remove_page_parameter request=request %}" class="link--clean" rel="nofollow">
             <i class="fa fa-search-plus"></i> Ver similares
           </a>
         </div>

--- a/templates/product/_items.html
+++ b/templates/product/_items.html
@@ -52,7 +52,7 @@
           {% endif %}
         </div>
         <div style="padding-top: 5px">
-          <a href="{{ product.get_similar }}?{% remove_page_parameter request=request %}" class="link--clean">
+          <a href="{{ product.get_similar }}?{% remove_page_parameter request=request %}" class="link--clean" rel="nofollow">
             <i class="fa fa-search-plus"></i> Ver similares
           </a>
         </div>


### PR DESCRIPTION
Basically, we don't want/need Google to use/see the similarity functionality because:
1. Its duplicate data
2. It makes crawling our site slower
3. It generates more overhead on our servers